### PR TITLE
[codex] docs: close pure-mcp descriptor ambiguity (signed replay)

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -22,6 +22,7 @@ still need a human to push the final publish button.
 
 | Surface | Status | Truthful claim |
 | --- | --- | --- |
+| Pure-MCP registry descriptor | Submission-ready-unlisted | Root [`server.json`](./server.json) names the canonical pure-MCP surface without claiming a live registry publication. |
 | Codex bundle | Submission-ready-unlisted | Repo-owned config and marketplace-compatible sample exist, but no live directory listing is claimed. |
 | Claude Code bundle | Submission-ready-unlisted | Repo-owned marketplace-compatible bundle exists, but no live marketplace listing is claimed. |
 | OpenClaw / ClawHub bundle | Submission-ready-unlisted | Repo-owned bundle and proof loop exist, but no live ClawHub listing is claimed. |
@@ -54,14 +55,16 @@ Read the distribution story in this order:
 
 1. [`README.md`](./README.md)
 2. [`manifest.yaml`](./manifest.yaml)
-3. [`examples/public-distribution/README.md`](./examples/public-distribution/README.md)
-4. [`examples/public-distribution/docker-runtime-submission.manifest.json`](./examples/public-distribution/docker-runtime-submission.manifest.json)
-5. [`examples/public-distribution/openclaw-public-ready.manifest.json`](./examples/public-distribution/openclaw-public-ready.manifest.json)
+3. [`server.json`](./server.json)
+4. [`examples/public-distribution/README.md`](./examples/public-distribution/README.md)
+5. [`examples/public-distribution/docker-runtime-submission.manifest.json`](./examples/public-distribution/docker-runtime-submission.manifest.json)
+6. [`examples/public-distribution/openclaw-public-ready.manifest.json`](./examples/public-distribution/openclaw-public-ready.manifest.json)
 
 ## What We Still Do Not Claim
 
 - a live official Codex directory listing
 - a live Claude Code marketplace listing
+- a live MCP registry listing
 - a live ClawHub listing
 - a published public Docker image
 - a managed hosted deployment or SaaS

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ maintenance.
 [Distribution Guide](./DISTRIBUTION.md) |
 [Integrations Guide](./INTEGRATIONS.md) |
 [Submission Manifest](./manifest.yaml) |
+[MCP Descriptor](./server.json) |
+[Canonical Skill Packet](./plugins/openui-workspace-delivery/README.md) |
 [Distribution Bundle](./examples/public-distribution/README.md) |
 [Discovery Guide](./docs/discovery-surfaces.md) |
-[Skills Product Line](./examples/skills/README.md) |
+[Skills Mirror](./examples/skills/README.md) |
 [Docs Index](./docs/index.md) |
 [Tags](https://github.com/xiaojiou176-open/openui-mcp-studio/tags) |
 [Discussions](https://github.com/xiaojiou176-open/openui-mcp-studio/discussions)
@@ -68,8 +70,22 @@ Use the shortest route that matches the job in your head:
 | --- | --- |
 | "What does the repo do in one screen?" | [`README.md`](./README.md) and the [Pages Front Door](https://xiaojiou176-open.github.io/openui-mcp-studio/) |
 | "How do I install, submit, or package this truthfully?" | [`DISTRIBUTION.md`](./DISTRIBUTION.md) and [`manifest.yaml`](./manifest.yaml) |
+| "Where is the canonical pure-MCP descriptor?" | [`server.json`](./server.json) |
 | "Which client or host is this actually ready for?" | [`INTEGRATIONS.md`](./INTEGRATIONS.md) |
+| "Where is the current pure-skills reviewer packet?" | [`plugins/openui-workspace-delivery/README.md`](./plugins/openui-workspace-delivery/README.md) |
 | "Where are the repo-owned install bundles and proof loops?" | [`examples/public-distribution/README.md`](./examples/public-distribution/README.md) and [`examples/skills/README.md`](./examples/skills/README.md) |
+
+## Canonical Public Roots
+
+Use these layers like a storefront, a boxed product, and a machine room instead
+of treating every folder as a competing front door.
+
+- **Canonical public root:** this root [`README.md`](./README.md) plus the root [`manifest.yaml`](./manifest.yaml)
+- **Canonical pure-MCP registry descriptor:** [`server.json`](./server.json)
+- **Canonical pure-skills packet:** [`plugins/openui-workspace-delivery/`](./plugins/openui-workspace-delivery/)
+- **Pure-MCP runtime support surface:** [`services/mcp-server/README.md`](./services/mcp-server/README.md)
+- **Repo-frontdoor mirrors and supporting install shelves:** [`examples/public-distribution/`](./examples/public-distribution/) and [`examples/skills/`](./examples/skills/)
+- **Installable package SSOT:** [`packages/skills-kit/`](./packages/skills-kit/)
 
 ## What You Get Today
 
@@ -77,8 +93,10 @@ Use the shortest route that matches the job in your head:
 - **Primary distribution artifact:** this public GitHub repo
 - **Install-ready client surfaces:** Codex, Claude Code, and generic MCP hosts
 - **Front-row compatible clients:** OpenCode and OpenClaw through the same repo-owned MCP contract and bundle set
-- **Official repo-owned skill product line:** `@openui/skills-kit` plus the repo mirror under `examples/skills/`
+- **Canonical pure-skills reviewer packet:** `plugins/openui-workspace-delivery/`
+- **Official repo-owned skill product line:** installable package SSOT in `@openui/skills-kit`, with a repo mirror under `examples/skills/`
 - **Submission-ready public packaging:** top-level distribution/integration guides, root `manifest.yaml`, and repo-owned Docker/OpenClaw submission packets that still refuse to claim a live listing
+- **Canonical pure-MCP descriptor lane:** root `server.json` now gives the repo one machine-readable MCP card without claiming that registry publication has already happened
 - **Supporting lanes:** self-hosted Hosted API and `@openui/sdk`
 - **Planned, not current:** live marketplace publication, registry publication, managed hosted deployment, and any claim that a Docker image or catalog listing is already published
 
@@ -97,7 +115,8 @@ Use the shortest route that matches the job in your head:
 
 - an official Codex directory entry
 - a listed Claude Code marketplace item
-- a live OpenClaw / ClawHub listing
+- a live root-repo OpenClaw / ClawHub listing
+- live official MCP registry publication for the root repo artifact
 - a managed hosted runtime or SaaS
 - a public Docker image or Docker-first install path
 
@@ -927,7 +946,7 @@ Current truth is:
 
 What still does **not** exist as current truth:
 
-- a live listed marketplace / plugin / ClawHub entry
+- a live listed root-repo marketplace / plugin / ClawHub entry
 - live registry publication for the root repo artifact
 - a public Docker runtime distribution
 - managed hosted SaaS deployment

--- a/contracts/governance/root-allowlist.json
+++ b/contracts/governance/root-allowlist.json
@@ -47,6 +47,7 @@
 		"pyproject.toml",
 		"README.md",
 		"SECURITY.md",
+		"server.json",
 		"SUPPORT.md",
 		"tsconfig.json",
 		"vitest.config.ts",

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,6 +11,7 @@ published_surfaces:
   - github-releases
   - repo-owned-proof-docs
 submission_ready_surfaces:
+  - pure-mcp-registry-descriptor
   - codex-bundle
   - claude-code-bundle
   - openclaw-clawhub-bundle
@@ -20,14 +21,19 @@ truth_routes:
   storefront: README.md
   distribution: DISTRIBUTION.md
   integrations: INTEGRATIONS.md
-  bundle_index: examples/public-distribution/README.md
+  mcp_registry_descriptor: server.json
+  canonical_skill_packet: plugins/openui-workspace-delivery/README.md
+  mcp_runtime: services/mcp-server/README.md
+  public_distribution_mirror: examples/public-distribution/README.md
+  skills_mirror: examples/skills/README.md
+  installable_skills_package: packages/skills-kit/manifest.json
   docker_bundle: examples/public-distribution/docker-runtime-submission.manifest.json
   openclaw_bundle: examples/public-distribution/openclaw-public-ready.manifest.json
-  skills_line: packages/skills-kit/manifest.json
 claims_not_made:
   - no live codex directory listing is claimed
   - no live claude marketplace listing is claimed
-  - no live clawhub listing is claimed
+  - no live root-repo clawhub listing is claimed
+  - no live official MCP registry publication is claimed
   - no published public docker image is claimed
   - no managed hosted runtime is claimed
 operator_only_follow_through:

--- a/plugins/openui-workspace-delivery/README.md
+++ b/plugins/openui-workspace-delivery/README.md
@@ -1,21 +1,38 @@
 # OpenUI Workspace Delivery
 
-This bundle is the repo-owned Claude Code marketplace-compatible package for
-OpenUI MCP Studio.
+This folder is the canonical pure-skills packet for OpenUI MCP Studio.
 
-What it gives you:
+The canonical public root for the product still lives at the repo root:
+`../../README.md` plus `../../manifest.yaml`.
+The canonical machine-readable descriptor for the pure-MCP lane now lives at
+`../../server.json`.
 
-- install guidance without browsing the whole repo first
-- a first-proof command route
-- a skill pack that keeps the local MCP install, proof loop, and truth
-  boundaries together
-- a bundle shape that OpenClaw can also consume as a Claude-compatible plugin
+It is meant to teach an agent four things without sending the reviewer back to
+repo-root docs first:
 
-What it is not:
+- how to install the local MCP server
+- how to attach it to OpenHands or OpenClaw
+- which UI-generation tools are safe to use first
+- what the shortest proof loop looks like
 
-- not an Anthropic marketplace listing
-- not a managed runtime
-- not proof that the local MCP server is already wired into Claude Code for you
+## Included files
 
-Use the sample bundle config in `samples/claude-code.mcp.json` together with
-the repo-owned starter bundles under `packages/skills-kit/starter-bundles/`.
+- `SKILL.md`
+- `manifest.yaml`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`
+
+## Truth boundary
+
+- this packet is a submission-ready-unlisted OpenClaw / ClawHub-style packet
+- it is still not a live vendor marketplace listing
+- it does not claim a hosted runtime
+- it does not claim vendor approval or an official ClawHub placement
+
+Use the host configs and proof loop in `references/` first. Treat the older
+`commands/` and `samples/` files as supporting material, not as the primary
+reviewer packet.

--- a/plugins/openui-workspace-delivery/SKILL.md
+++ b/plugins/openui-workspace-delivery/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: openui-workspace-delivery
+description: Teach an agent how to install OpenUI MCP Studio, connect it to a host, and use the core UI generation and review workflow without overclaiming a live marketplace listing.
+version: 1.0.0
+triggers:
+  - openui
+  - openui-mcp-studio
+  - openui workspace delivery
+  - shadcn generation
+  - UI shipping
+---
+
+# OpenUI Workspace Delivery
+
+Teach the agent how to install, connect, and use OpenUI MCP Studio as a local
+MCP-first UI generation and review workspace.
+
+## Use this skill when
+
+- the user wants to generate or review shadcn-style UI from a local MCP server
+- the host can run a local `stdio` MCP server
+- the user wants one inspectable proof loop before any public claim
+
+## What this packet teaches
+
+- how to wire the local OpenUI MCP server into OpenHands or OpenClaw
+- which OpenUI MCP tools are safe and useful first
+- how to move from installation to a first proof loop
+- how to keep claims grounded in local MCP and repo-owned proof instead of
+  marketplace hype
+
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the proof loop in [references/DEMO.md](references/DEMO.md)
+5. If attach or proof fails, use
+   [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md)
+
+## Recommended workflow
+
+1. `openui_scan_workspace_profile`
+2. `openui_plan_change`
+3. `openui_generate_ui`
+4. `openui_quality_gate`
+5. `openui_build_review_bundle`
+
+## Suggested first prompt
+
+Use OpenUI MCP Studio to inspect this workspace and prepare one safe-first UI
+delivery step. Start with `openui_scan_workspace_profile` and
+`openui_plan_change`. If the workspace looks healthy, run `openui_generate_ui`
+for one small component or page change, then run `openui_quality_gate` and
+summarize what a reviewer should inspect next.
+
+## Success checks
+
+- the host can launch the OpenUI MCP server from the provided config
+- the workspace scan returns a real profile instead of placeholder text
+- the plan/generate flow yields a concrete UI output or change plan
+- the proof loop stays inside local MCP and repo-owned evidence
+
+## Boundaries
+
+- OpenUI MCP Studio stays a local MCP and repo-owned proof workflow
+- this packet does not claim a live ClawHub listing or a vendor marketplace
+  listing
+- this packet does not claim a hosted runtime or hosted API publication

--- a/plugins/openui-workspace-delivery/manifest.yaml
+++ b/plugins/openui-workspace-delivery/manifest.yaml
@@ -1,0 +1,43 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: openui-workspace-delivery
+  display_name: OpenUI Workspace Delivery
+  version: 1.0.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: submission-ready-unlisted
+    package_shape: skill-folder
+    channel_role: host-native skill registry
+    submit_via: later owner/operator publication after fresh verification
+  openhands-extensions:
+    status: folder-ready-not-submitted
+    package_shape: skill-folder
+    channel_role: host-native extensions registry
+    submit_via: submit this folder as skills/openui-workspace-delivery/ after Wave 2 verification
+
+boundaries:
+  product_identity: Local MCP-first UI generation and review workspace for OpenUI MCP Studio.
+  canonical_packet_role: Canonical pure-skills packet for the repo; repo root remains the canonical public root.
+  canonical_repo_version: 0.1.0
+  official_listing_state: no live registry or marketplace listing is claimed
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No live ClawHub listing exists yet
+    - No live official marketplace listing exists yet
+    - No hosted runtime or managed API publication is claimed
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/plugins/openui-workspace-delivery/references/CAPABILITIES.md
+++ b/plugins/openui-workspace-delivery/references/CAPABILITIES.md
@@ -1,0 +1,42 @@
+# OpenUI MCP Studio Capabilities
+
+OpenUI MCP Studio exposes a local UI generation and review workflow.
+
+## Core workflow tools
+
+- `openui_scan_workspace_profile`
+- `openui_plan_change`
+- `openui_generate_ui`
+- `openui_convert_react_shadcn`
+- `openui_make_react_page`
+- `openui_apply_files`
+- `openui_quality_gate`
+- `openui_next_smoke`
+- `openui_ship_react_page`
+
+## Delivery-intelligence tools
+
+- `openui_build_acceptance_pack`
+- `openui_build_review_bundle`
+- `openui_ship_feature_flow`
+
+## Supporting tools
+
+- `openui_refine_ui`
+- `openui_review_uiux`
+- `openui_list_models`
+- `openui_embed_content`
+
+## Recommended first-use order
+
+1. `openui_scan_workspace_profile`
+2. `openui_plan_change`
+3. `openui_generate_ui`
+4. `openui_quality_gate`
+5. `openui_build_review_bundle`
+
+## Boundary
+
+- good fit: local MCP-first UI generation, review, and proof
+- not a fit: claiming hosted runtime, official marketplace listing, or a vendor
+  managed install surface

--- a/plugins/openui-workspace-delivery/references/DEMO.md
+++ b/plugins/openui-workspace-delivery/references/DEMO.md
@@ -1,0 +1,26 @@
+# OpenUI MCP Studio First-Success Demo
+
+This is the shortest proof loop that shows the packet is real.
+
+## Demo prompt
+
+Use OpenUI MCP Studio to inspect this workspace and prepare one safe-first UI
+delivery step. Start with `openui_scan_workspace_profile` and
+`openui_plan_change`. If the workspace looks healthy, run `openui_generate_ui`
+for one small component or page change, then run `openui_quality_gate` and
+summarize what a reviewer should inspect next.
+
+## Expected tool sequence
+
+1. `openui_scan_workspace_profile`
+2. `openui_plan_change`
+3. `openui_generate_ui`
+4. `openui_quality_gate`
+5. `openui_build_review_bundle`
+
+## Visible success criteria
+
+- the MCP server launches from the provided config
+- the workspace profile is real and repo-specific
+- the generation step produces a concrete UI payload or change plan
+- the quality gate reports repo-owned findings instead of placeholder prose

--- a/plugins/openui-workspace-delivery/references/INSTALL.md
+++ b/plugins/openui-workspace-delivery/references/INSTALL.md
@@ -1,0 +1,38 @@
+# Install And Attach OpenUI MCP Studio
+
+Use the current repo-native MCP path first.
+
+## Quickest local setup
+
+1. Clone the public repository:
+
+```bash
+git clone https://github.com/xiaojiou176-open/openui-mcp-studio.git
+cd openui-mcp-studio
+npm install
+npm run build
+```
+
+2. Confirm the compiled MCP entry exists:
+
+- `.runtime-cache/build/mcp-server/services/mcp-server/src/main.js`
+
+3. Replace the placeholder server path in the host config snippets with the real
+   local checkout path, and replace `GEMINI_API_KEY` with a real local secret
+   before attach.
+
+4. Attach the host with one of the config snippets in this folder.
+
+## Current truthful install mode
+
+- protocol: `stdio`
+- transport: `stdio`
+- runtime: local repo checkout
+- public marketplace listing: not claimed
+
+## What to hand back to the agent
+
+- whether the build output exists
+- whether `GEMINI_API_KEY` is available
+- which host you are attaching
+- whether the proof loop commands complete

--- a/plugins/openui-workspace-delivery/references/OPENCLAW_MCP_CONFIG.json
+++ b/plugins/openui-workspace-delivery/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,15 @@
+{
+  "mcp": {
+    "servers": {
+      "openui": {
+        "command": "node",
+        "args": [
+          "/ABSOLUTE/PATH/TO/OPENUI-MCP-STUDIO/.runtime-cache/build/mcp-server/services/mcp-server/src/main.js"
+        ],
+        "env": {
+          "GEMINI_API_KEY": "your_key"
+        }
+      }
+    }
+  }
+}

--- a/plugins/openui-workspace-delivery/references/OPENHANDS_MCP_CONFIG.json
+++ b/plugins/openui-workspace-delivery/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "openui": {
+      "command": "node",
+      "args": [
+        "/ABSOLUTE/PATH/TO/OPENUI-MCP-STUDIO/.runtime-cache/build/mcp-server/services/mcp-server/src/main.js"
+      ],
+      "env": {
+        "GEMINI_API_KEY": "your_key"
+      }
+    }
+  }
+}

--- a/plugins/openui-workspace-delivery/references/README.md
+++ b/plugins/openui-workspace-delivery/references/README.md
@@ -1,0 +1,18 @@
+# OpenUI Workspace Delivery Packet References
+
+This folder keeps the public packet self-contained.
+
+## Files
+
+- `INSTALL.md`
+  - local install and attach guide
+- `OPENHANDS_MCP_CONFIG.json`
+  - OpenHands-ready config snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - OpenClaw-ready config snippet
+- `CAPABILITIES.md`
+  - safe-first tool map and capability boundaries
+- `DEMO.md`
+  - first-success generation and review loop
+- `TROUBLESHOOTING.md`
+  - shortest checks before escalation

--- a/plugins/openui-workspace-delivery/references/TROUBLESHOOTING.md
+++ b/plugins/openui-workspace-delivery/references/TROUBLESHOOTING.md
@@ -1,0 +1,32 @@
+# OpenUI MCP Studio Troubleshooting
+
+Use these checks before escalating.
+
+## 1. Build output path is missing
+
+- run `npm install`
+- run `npm run build`
+- confirm `.runtime-cache/build/mcp-server/services/mcp-server/src/main.js`
+  exists
+
+## 2. Gemini key is missing
+
+- provide `GEMINI_API_KEY` in the host config
+- rerun any local env check you rely on before attaching again
+
+## 3. You only need the shortest proof loop
+
+- run `openui-mcp-studio surface-guide --json`
+- run `openui-mcp-studio ecosystem-guide --json`
+- run `npm run repo:doctor`
+
+## 4. The claim sounds bigger than reality
+
+Stop and re-check:
+
+- `DISTRIBUTION.md`
+- `INTEGRATIONS.md`
+- `manifest.yaml`
+
+Do not claim ClawHub, official marketplace, or hosted runtime status unless
+fresh read-back exists.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.xiaojiou176-open/openui-mcp-studio",
+  "title": "OpenUI MCP Studio",
+  "description": "Local stdio MCP workflow for turning UI briefs into React + shadcn files with review, proof, and acceptance before ship.",
+  "websiteUrl": "https://xiaojiou176-open.github.io/openui-mcp-studio/",
+  "repository": {
+    "url": "https://github.com/xiaojiou176-open/openui-mcp-studio",
+    "source": "github"
+  },
+  "version": "0.3.0"
+}

--- a/services/mcp-server/README.md
+++ b/services/mcp-server/README.md
@@ -4,6 +4,12 @@
 
 `services/mcp-server` is the protocol entrypoint for this repository. It owns the MCP stdio server, tool registration, quality-gate orchestration, Gemini runtime orchestration, and the compatibility-facing public surface.
 
+The canonical public root still lives at the repo root (`README.md` +
+`manifest.yaml`), and the canonical machine-readable descriptor for the pure-MCP
+lane now lives at `../../server.json`. This document remains the runtime support
+surface for the pure-MCP lane, not a claim that the repo already has a live
+registry listing.
+
 ## Out Of Scope
 
 - Implementing the actual product frontend pages


### PR DESCRIPTION
## Summary
- replay the closure diff from #40 onto a newly SSH-signed branch
- preserve the same repo-side change while removing the unsigned-commit policy blocker
- keep #40 as historical context for the original unsigned path

## Test Plan
- [x] pre-push local gate passed during branch push
- [x] commit is SSH-signed and verified by GitHub
- [ ] fresh PR checks

## Breaking Changes
None

## Related Issues
Supersedes #40 for the signed-commit landing path