### PR TITLE
[codex] feat(frontdoor): land W4 reviewer-first routing cut

### DIFF
--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -52,13 +52,12 @@ const docsStructuredData = buildStructuredDiscoveryJsonLd({
 
 const DOC_SHELVES = [
 	{
-		id: "docs-index",
-		title: "README storefront",
+		id: "first-minute-walkthrough",
+		title: "First-minute walkthrough",
 		body:
-			"Start here when the first question is what the product does and which route to open next.",
-		link: SITE_BRAND.docs.readme,
-		cta: "Open README storefront",
-		external: true,
+			"Use this when you want the shortest guided route from front door to proof, workbench, and one real command before you branch into longer docs.",
+		link: "/walkthrough",
+		cta: "Open walkthrough route",
 	},
 	{
 		id: "proof-faq",
@@ -67,6 +66,15 @@ const DOC_SHELVES = [
 			"Use the proof desk when you need the meaning of proof, review, acceptance, and the boundaries between repo-owned evidence and human judgment.",
 		link: "/proof",
 		cta: "Open proof desk",
+	},
+	{
+		id: "docs-index",
+		title: "README storefront",
+		body:
+			"Open the README after the route is already clear and you want the GitHub-facing storefront wording in its canonical home.",
+		link: SITE_BRAND.docs.readme,
+		cta: "Open README storefront",
+		external: true,
 	},
 	{
 		id: "evaluator-checklist",
@@ -83,14 +91,6 @@ const DOC_SHELVES = [
 			"Use this when the question becomes how README, routes, release assets, and GitHub storefront should keep telling one story.",
 		link: SITE_BRAND.docs.publicSurfaceGuide,
 		cta: "Jump to public surface notes",
-	},
-	{
-		id: "first-minute-walkthrough",
-		title: "First-minute walkthrough",
-		body:
-			"Use this when you want a guided route from front door to proof, workbench, and one real command.",
-		link: "/walkthrough",
-		cta: "Open walkthrough route",
 	},
 	{
 		id: "release-proof-shelf",
@@ -152,27 +152,30 @@ export default function DocsDiscoveryPage() {
 			>
 				<section className="rounded-[var(--radius-xl)] border border-border/70 bg-frontdoor-hero px-6 py-8 shadow-xl sm:px-8">
 					<div className="space-y-4">
-						<Badge className="bg-primary/95 text-primary-foreground">
-							Docs discovery route
-						</Badge>
-						<h1 className="max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl">
-							Keep the public docs inside the product story.
-						</h1>
-						<p className="max-w-3xl text-base leading-7 text-muted-foreground sm:text-lg">
-							This route exists so visitors can understand the README storefront,
-							proof desk, evaluator checklist, release shelf, and ecosystem ledgers
-							without being dropped straight into GitHub blob pages before they know
-							what each document is for.
-						</p>
-						<div className="flex flex-wrap gap-3">
-							<Button asChild size="lg">
-								<Link href="/proof">Open the proof desk</Link>
-							</Button>
-							<Button asChild size="lg" variant="outline">
-								<Link href="/workbench">Open the operator desk</Link>
-							</Button>
+							<Badge className="bg-primary/95 text-primary-foreground">
+								Docs discovery route
+							</Badge>
+							<h1 className="max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl">
+								Keep the docs inside a guided route, not a blob dump.
+							</h1>
+							<p className="max-w-3xl text-base leading-7 text-muted-foreground sm:text-lg">
+								This route exists so visitors can learn the product in the same
+								order a reviewer would: guided path first, proof second, operator
+								desk third, and the longer shelves only after the first-screen
+								story is clear.
+							</p>
+							<div className="flex flex-wrap gap-3">
+								<Button asChild size="lg">
+									<Link href="/walkthrough">Open the walkthrough</Link>
+								</Button>
+								<Button asChild size="lg" variant="outline">
+									<Link href="/proof">Open the proof desk</Link>
+								</Button>
+								<Button asChild size="lg" variant="ghost">
+									<Link href="/workbench">Open the operator desk</Link>
+								</Button>
+							</div>
 						</div>
-					</div>
 				</section>
 
 				<section className="space-y-4" id="discovery-chain">
@@ -184,9 +187,10 @@ export default function DocsDiscoveryPage() {
 							Read the product in this order.
 						</h2>
 						<p className="max-w-3xl text-sm leading-7 text-muted-foreground">
-							The goal is simple: storefront first, then proof, then operator
-							context, then machine-readable surfaces. That keeps discovery from
-							feeling like a source-code scavenger hunt.
+							The goal is simple: guided route first, proof second, operator
+							context third, then the longer shelves and machine-readable
+							surfaces. That keeps discovery from feeling like a source-code
+							scavenger hunt.
 						</p>
 					</div>
 					<div className="grid gap-4 lg:grid-cols-3">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -90,18 +90,18 @@ export default async function FrontdoorHomePage() {
 
               <div className="flex flex-wrap gap-3">
                 <Button asChild size="lg">
-                  <Link href="/proof" data-testid="hero-cta-proof">
-                    {messages.home.heroCtas.proof}
-                  </Link>
-                </Button>
-                <Button asChild size="lg" variant="outline">
                   <Link href="/walkthrough" data-testid="hero-cta-walkthrough">
                     {messages.home.heroCtas.walkthrough}
                   </Link>
                 </Button>
+                <Button asChild size="lg" variant="outline">
+                  <Link href="/proof" data-testid="hero-cta-proof">
+                    {messages.home.heroCtas.proof}
+                  </Link>
+                </Button>
                 <Button asChild size="lg" variant="ghost">
-                  <Link href="/docs" data-testid="hero-cta-compare">
-                    {messages.home.heroCtas.compare}
+                  <Link href="/workbench" data-testid="hero-cta-workbench">
+                    {messages.home.heroCtas.workbench}
                   </Link>
                 </Button>
               </div>

--- a/apps/web/components/frontdoor-shell.tsx
+++ b/apps/web/components/frontdoor-shell.tsx
@@ -21,12 +21,14 @@ export async function FrontdoorShell({
   const messages = getFrontdoorMessages(locale);
   const navLinks = [
     { href: "/", label: messages.shell.navLinks.home },
+    { href: "/walkthrough", label: messages.shell.navLinks.walkthrough },
     { href: "/proof", label: messages.shell.navLinks.proof },
+    { href: "/workbench", label: messages.shell.navLinks.workbench },
     { href: "/docs", label: messages.shell.navLinks.docs },
     { href: "/compare", label: messages.shell.navLinks.compare },
-    { href: "/walkthrough", label: messages.shell.navLinks.walkthrough },
-    { href: "/workbench", label: messages.shell.navLinks.workbench },
   ];
+  const primaryNavLinks = navLinks.slice(1, 4);
+  const secondaryNavLinks = [navLinks[0], ...navLinks.slice(4)];
 
   return (
     <>
@@ -67,23 +69,48 @@ export async function FrontdoorShell({
 
           <nav
             aria-label={messages.shell.quickNavigationLabel}
-            className="flex flex-wrap gap-2"
+            className="space-y-3"
           >
-            {navLinks.map((item) => (
-              <Button
-                key={item.href}
-                asChild
-                variant={item.href === activeHref ? "secondary" : "ghost"}
-                size="sm"
-              >
-                <Link
-                  href={item.href}
-                  aria-current={item.href === activeHref ? "page" : undefined}
+            <div className="flex flex-wrap gap-2">
+              {primaryNavLinks.map((item) => (
+                <Button
+                  key={item.href}
+                  asChild
+                  variant={item.href === activeHref ? "secondary" : "outline"}
+                  size="sm"
                 >
-                  {item.label}
-                </Link>
-              </Button>
-            ))}
+                  <Link
+                    href={item.href}
+                    aria-current={item.href === activeHref ? "page" : undefined}
+                  >
+                    {item.label}
+                  </Link>
+                </Button>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {secondaryNavLinks.map((item) => (
+                <Button
+                  key={item.href}
+                  asChild
+                  variant={item.href === activeHref ? "secondary" : "ghost"}
+                  size="sm"
+                >
+                  <Link
+                    href={item.href}
+                    aria-current={item.href === activeHref ? "page" : undefined}
+                  >
+                    {item.label}
+                  </Link>
+                </Button>
+              ))}
+            </div>
+            <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-border/70 bg-card/80 px-3 py-2 text-xs text-muted-foreground">
+              <Badge variant="outline" className="w-fit border-primary/20 bg-primary/5">
+                {messages.shell.routeGuideBadge}
+              </Badge>
+              <p className="max-w-4xl leading-6">{messages.shell.routeGuideBody}</p>
+            </div>
           </nav>
         </div>
       </header>

--- a/apps/web/lib/frontdoor-content.ts
+++ b/apps/web/lib/frontdoor-content.ts
@@ -420,11 +420,11 @@ export const MACHINE_READABLE_SURFACES = [
 ] as const;
 
 export const FRONTDOOR_LINKS = [
-  { href: "/docs", label: "Discovery docs hub" },
-  { href: "/proof", label: "30-second proof" },
-  { href: "/compare", label: "Alternatives and compare" },
   { href: "/walkthrough", label: "First-minute walkthrough" },
+  { href: "/proof", label: "30-second proof" },
   { href: "/workbench", label: "Open the operator desk" },
+  { href: "/docs", label: "Discovery docs hub" },
+  { href: "/compare", label: "Alternatives and compare" },
 ];
 
 export const FRONTDOOR_ROUTE_CONTRACTS = [
@@ -515,10 +515,10 @@ export const DISCOVERY_CHAIN = [
   },
   {
     step: "Step 3",
-    title: "Compare",
-    href: "/compare",
-    role: "decision surface",
-    body: "Explain why OpenUI fits repo-aware UI shipping better than hosted builders or generic coding-agent traffic.",
+    title: "First-minute walkthrough",
+    href: "/walkthrough",
+    role: "guided route",
+    body: "Give newcomers the shortest recommended route from front door to proof, workbench, and one real repo-owned command.",
   },
   {
     step: "Step 4",
@@ -543,20 +543,27 @@ export const DISCOVERY_CHAIN = [
   },
   {
     step: "Step 7",
+    title: "Compare",
+    href: "/compare",
+    role: "decision surface",
+    body: "Explain why OpenUI fits repo-aware UI shipping better than hosted builders or generic coding-agent traffic when category fit is still the open question.",
+  },
+  {
+    step: "Step 8",
     title: "Machine-readable discovery",
     href: "/llms.txt",
     role: "short LLM summary",
     body: "Expose the shortest English-first route, builder, and boundary summary for LLM, search, and tooling consumers.",
   },
   {
-    step: "Step 8",
+    step: "Step 9",
     title: "Frontdoor JSON",
     href: "/api/frontdoor",
     role: "structured discovery contract",
     body: "Expose routes, bindings, builder order, public bundle pointers, and operator-only follow-through in one JSON surface.",
   },
   {
-    step: "Step 9",
+    step: "Step 10",
     title: "Manifest and crawl metadata",
     href: "/manifest.webmanifest",
     role: "browser and crawler metadata",

--- a/apps/web/lib/i18n/messages.ts
+++ b/apps/web/lib/i18n/messages.ts
@@ -91,6 +91,8 @@ type FrontdoorMessages = {
   shell: {
     navigationLabel: string;
     quickNavigationLabel: string;
+    routeGuideBadge: string;
+    routeGuideBody: string;
     githubLabel: string;
     productLine: string;
     navLinks: {
@@ -117,7 +119,7 @@ type FrontdoorMessages = {
     heroCtas: {
       proof: string;
       walkthrough: string;
-      compare: string;
+      workbench: string;
     };
     heroSignals: string[];
     guidedPathsBadge: string;
@@ -321,6 +323,9 @@ const FRONTDOOR_MESSAGES: Record<AppLocale, FrontdoorMessages> = {
     shell: {
       navigationLabel: "Front door navigation",
       quickNavigationLabel: "Front door quick navigation",
+      routeGuideBadge: "Recommended order",
+      routeGuideBody:
+        "Start with the walkthrough, confirm trust in the proof desk, then open the operator desk only when you need the repo-local decision surface. Docs and compare stay one click away, but they are secondary to that first-screen path.",
       githubLabel: "GitHub",
       productLine:
         "UI/UX delivery companion with plugin-grade package surfaces for Codex and Claude Code, plus OpenClaw-side packaging work.",
@@ -349,31 +354,31 @@ const FRONTDOOR_MESSAGES: Record<AppLocale, FrontdoorMessages> = {
       heroBody:
         "OneClickUI.ai is the front door for OpenUI MCP Studio: an MCP-native UI/UX delivery and review workflow that plans the change, writes real files, and now carries a plugin-grade starter/config/proof package for Codex, Claude Code, and OpenClaw-side packaging work. It still stays narrower and more honest than a generic coding-agent shell.",
       heroCtas: {
-        proof: "See the 30-second proof",
         walkthrough: "Take the first-minute walkthrough",
-        compare: "Open install and proof docs",
+        proof: "See the 30-second proof",
+        workbench: "Open the operator desk",
       },
       heroSignals: [...HERO_SIGNALS],
       guidedPathsBadge: "Start here",
       guidedPathsTitle:
         "Choose the route that matches how you are evaluating the product.",
       guidedPathsBody:
-        "The front door should feel like a guide, not a brochure. Start with proof or the walkthrough first, then drop into the operator desk only when the product story already makes sense.",
+        "The front door should feel like a guide, not a brochure. Most newcomers should take the walkthrough first, confirm trust in the proof desk second, and only then drop into the operator desk.",
       guidedPaths: [
+        {
+          badge: "Recommended first stop",
+          title:
+            "Take the walkthrough when you want the shortest newcomer path through the product story.",
+          body: "Go to /walkthrough if you want the recommended order from storefront to proof, docs, and the operator desk without deciding the route yourself.",
+          href: "/walkthrough",
+          cta: "Open the walkthrough",
+        },
         {
           badge: "Need proof first",
           title: "Open the evidence desk when trust is your first question.",
           body: "Go to /proof if you want the shortest route through prompt, changed files, review bundle, acceptance, and operator meaning before you touch the interactive desk.",
           href: "/proof",
           cta: "Open the proof desk",
-        },
-        {
-          badge: "Need the guided order",
-          title:
-            "Take the walkthrough when you want the shortest newcomer path through the product story.",
-          body: "Go to /walkthrough if you want the recommended order from storefront to proof, docs, and the operator desk without deciding the route yourself.",
-          href: "/walkthrough",
-          cta: "Open the walkthrough",
         },
         {
           badge: "Already in Codex or Claude Code",
@@ -868,6 +873,9 @@ const FRONTDOOR_MESSAGES: Record<AppLocale, FrontdoorMessages> = {
     shell: {
       navigationLabel: "前门导航",
       quickNavigationLabel: "前门快捷导航",
+      routeGuideBadge: "推荐顺序",
+      routeGuideBody:
+        "默认先走上手路径，再到证据台确认可信度，最后在真正需要做 repo-local 判断时才进入工作台。Docs 和对比页保留一跳可达，但不是第一屏的主路线。",
       githubLabel: "GitHub",
       productLine: "面向 Codex 与 Claude Code 团队的 UI/UX 交付伙伴。",
       navLinks: {
@@ -894,9 +902,9 @@ const FRONTDOOR_MESSAGES: Record<AppLocale, FrontdoorMessages> = {
       heroBody:
         "OneClickUI.ai 是 OpenUI MCP Studio 的前门：它不是泛化开发代理外壳，而是一条 MCP-native 的 UI/UX 交付与评审工作流，会先规划变更、再写入真实文件，并在你信任结果之前把变更文件、评审结论和验收状态摆在台面上。现在它还带着一套可直接拿来用的 starter bundle、proof loop 和故障排查入口，最适合已经在 Codex 或 Claude Code 里推进仓库工作的团队，以及需要评估 OpenClaw public-ready 包装的人。",
       heroCtas: {
-        proof: "查看 30 秒证据链",
         walkthrough: "按上手路径走一遍",
-        compare: "打开安装与证明文档",
+        proof: "查看 30 秒证据链",
+        workbench: "打开工作台",
       },
       heroSignals: [
         "把改动写进真实工作区",
@@ -909,21 +917,21 @@ const FRONTDOOR_MESSAGES: Record<AppLocale, FrontdoorMessages> = {
       guidedPathsBadge: "先从这里开始",
       guidedPathsTitle: "按你当前最在意的问题，选一条最短路线。",
       guidedPathsBody:
-        "前门应该像导览，不该像说明书。默认先走证据链或上手路径，再在真正需要时进入工作台，才不会让陌生访客过早掉进操盘台。",
+        "前门应该像导览，不该像说明书。大多数新访客先走上手路径，再去证据台，最后才在真正需要做 repo-local 判断时进入工作台，会更不容易迷路。",
       guidedPaths: [
+        {
+          badge: "推荐第一站",
+          title: "如果你想按最省脑力的顺序理解产品，就先走上手路径。",
+          body: "去 `/walkthrough`，按 storefront → proof → docs → operator desk 的顺序看，不必自己先猜应该点哪一个入口。",
+          href: "/walkthrough",
+          cta: "打开上手路径",
+        },
         {
           badge: "先看可信度",
           title: "如果你第一反应是“凭什么信它”，先打开证据台。",
           body: "去 `/proof`，先看提示词、变更文件、评审包、验收和操作者含义是怎么串成一条证据链的。",
           href: "/proof",
           cta: "打开证据台",
-        },
-        {
-          badge: "按推荐顺序走",
-          title: "如果你想按最省脑力的顺序理解产品，就先走上手路径。",
-          body: "去 `/walkthrough`，按 storefront → proof → docs → operator desk 的顺序看，不必自己先猜应该点哪一个入口。",
-          href: "/walkthrough",
-          cta: "打开上手路径",
         },
         {
           badge: "已经在用 Codex / Claude Code",

--- a/tests/e2e/frontdoor-home.spec.ts
+++ b/tests/e2e/frontdoor-home.spec.ts
@@ -47,7 +47,7 @@ test("frontdoor homepage explains the product, proof path, and next actions", as
 
 	await expect(page.getByTestId("hero-cta-proof")).toBeVisible();
 	await expect(page.getByTestId("hero-cta-walkthrough")).toBeVisible();
-	await expect(page.getByTestId("hero-cta-compare")).toBeVisible();
+	await expect(page.getByTestId("hero-cta-workbench")).toBeVisible();
 
 	await expect(
 		page.getByRole("heading", {

--- a/tests/frontdoor-i18n.test.ts
+++ b/tests/frontdoor-i18n.test.ts
@@ -22,8 +22,9 @@ describe("frontdoor i18n contract", () => {
 		expect(english.localeLabel).toBe("Language");
 		expect(chinese.localeLabel).toBe("语言");
 		expect(english.shell.productLine).toContain("Codex and Claude Code");
-		expect(chinese.home.guidedPaths[0]?.cta).toBe("打开证据台");
-		expect(english.home.guidedPaths[1]?.title).toContain("walkthrough");
+		expect(chinese.home.guidedPaths[0]?.cta).toBe("打开上手路径");
+		expect(english.home.guidedPaths[1]?.title).toContain("evidence desk");
+		expect(chinese.shell.routeGuideBadge).toBe("推荐顺序");
 		expect(english.compare.goThereFirst).toContain("hosted builder");
 		expect(chinese.compare.goThereFirst).toContain(
 			"最顺滑的托管式 builder 体验",
@@ -37,6 +38,7 @@ describe("frontdoor i18n contract", () => {
 		expect(chinese.home.builderEntryPoints[0]?.cta).toBe("打开 MCP 接入指南");
 		expect(chinese.home.builderEntryPoints[1]?.cta).toBe("打开 OpenAPI 契约");
 		expect(chinese.home.builderEntryPoints[2]?.cta).toBe("打开 readiness 文档");
+		expect(chinese.home.heroCtas.workbench).toBe("打开工作台");
 		expect(chinese.home.proofSectionTitle).toBe(
 			"提示词、产出、变更文件、评审包、证据链。",
 		);


### PR DESCRIPTION
## Summary
This PR lands the current 7-file W4 UI/UX first cut that was already repo-local verified but not yet Git/GitHub landed.

It keeps truth layers explicit:
- `#41` was the earlier signed replay closure path and is already merged.
- This PR is the separate reviewer-first frontdoor/docs routing residue that remained only in the local worktree.
- `#42` was closed because it accidentally inherited already-landed history from the old closure branch lineage.

## What changed
- promote `Walkthrough -> Proof -> Workbench` as the primary first-screen route
- demote `Home / Docs / Compare` to secondary quick navigation
- move the homepage hero CTA order to walkthrough first, proof second, workbench third
- update the docs hub hero/shelf order so guided route comes before README/blob-style discovery
- refresh frontdoor discovery-chain ordering and i18n/test expectations to match the new routing

## Fresh verification
- `npm run host:safety:check`
- `npm run lint:frontend`
- `npm test -- tests/frontdoor-i18n.test.ts tests/frontdoor-api-route.test.ts`
- `npm --workspace apps/web run typecheck`
- `npm --workspace apps/web run build`
- `npx playwright test --config=playwright.config.ts tests/e2e/frontdoor-home.spec.ts --project=chromium`
- pre-commit gate on commit
- pre-push gate on push

## Scope
Only the current dirty slice was landed:
- `apps/web/app/docs/page.tsx`
- `apps/web/app/page.tsx`
- `apps/web/components/frontdoor-shell.tsx`
- `apps/web/lib/frontdoor-content.ts`
- `apps/web/lib/i18n/messages.ts`
- `tests/e2e/frontdoor-home.spec.ts`
- `tests/frontdoor-i18n.test.ts`