### PR TITLE
docs: sync marketplace receipt truth

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -27,6 +27,9 @@ still need a human to push the final publish button.
 | Claude Code bundle | Repo-owned package | Repo-owned marketplace-compatible bundle exists, but no live marketplace listing is claimed. |
 | OpenHands extension lane | `OPEN / REVIEW_REQUIRED / BLOCKED` | Submitted via PR `#161`; current GitHub state is still review-required and blocked, not accepted. |
 | OpenClaw / ClawHub bundle | `listed_live` with moderation warning | The ClawHub page is listed live, but the current page still shows `Moderation verdict: suspicious` and `Detected: suspicious.llm_suspicious`. |
+| Goose Skills Marketplace | `OPEN / security-review-required` | Submitted via PR [`block/Agent-Skills#25`](https://github.com/block/Agent-Skills/pull/25); upstream validator passed, and the current visible blocker is security review / CODEOWNERS handling rather than a missing repo packet. |
+| agent-skill.co source repo | `OPEN / preview-authorization-blocked` | Submitted via PR [`heilcheng/awesome-agent-skills#181`](https://github.com/heilcheng/awesome-agent-skills/pull/181); the current visible blocker is upstream Vercel preview authorization rather than a missing repo packet. |
+| awesome-opencode project/resource lane | `not_submitted` | No awesome-opencode receipt is claimed today. OpenCode remains a compatibility surface in this repo, so a curated project/resource entry stays paused until there is a stricter Opencode-native fit decision. |
 | GHCR | `not_published` | The repo can explain the image contract and proof route, but no GHCR publish receipt is verified today. |
 | Public package / container lanes | No verified public receipt today | Package or container publication remains a later operator-owned proof step until a fresh receipt exists. |
 | `@openui/sdk` local pack/install lane | Repo-owned pack/install | Pack/install truth exists inside the repo, but registry publication remains operator-only. |
@@ -66,6 +69,9 @@ Read the distribution story in this order:
 - a live Claude Code marketplace listing
 - an Official MCP Registry submission or listing
 - a trust-cleared or vendor-approved ClawHub result
+- an accepted Goose marketplace listing beyond PR `#25`
+- an accepted agent-skill.co directory entry beyond PR `#181`
+- an awesome-opencode project/resource listing while OpenCode still stays a compatibility surface
 - a GHCR publication or any other published public Docker image
 - a managed hosted deployment or SaaS
 - any package or container publish that requires a human account action and has

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ of treating every folder as a competing front door.
 - **Front-row compatible clients:** OpenCode and OpenClaw through the same repo-owned MCP contract and bundle set
 - **Canonical pure-skills reviewer packet:** `plugins/openui-workspace-delivery/`
 - **Official repo-owned skill product line:** installable package SSOT in `@openui/skills-kit`, with a repo mirror under `examples/skills/`
-- **Current external truth ledger:** ClawHub is listed live, but the current page still shows `Moderation verdict: suspicious` and `Detected: suspicious.llm_suspicious`; OpenHands lives in `OPEN / REVIEW_REQUIRED / BLOCKED`; Official MCP Registry remains `not_submitted`
+- **Current external truth ledger:** ClawHub is listed live, but the current page still shows `Moderation verdict: suspicious` and `Detected: suspicious.llm_suspicious`; OpenHands lives in `OPEN / REVIEW_REQUIRED / BLOCKED`; Goose skills PR `block/Agent-Skills#25` is open with validation passed and upstream security review still pending; agent-skill index PR `heilcheng/awesome-agent-skills#181` is open with upstream preview authorization still blocking acceptance; Official MCP Registry remains `not_submitted`; awesome-opencode stays `not_submitted` because OpenCode is still a compatibility surface here, not a dedicated Opencode-native project shelf
 - **Canonical pure-MCP descriptor lane:** root `server.json` gives the repo one machine-readable MCP card without claiming that Official MCP Registry is already submitted
 - **Supporting lanes:** self-hosted Hosted API and `@openui/sdk`
 - **Later, not current:** managed hosted deployment, GHCR publication, and any public package or container receipt that has not been freshly verified today

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -23,8 +23,17 @@ external_truth:
     moderation_label: suspicious.llm_suspicious
   openhands_pr_161:
     status: OPEN / REVIEW_REQUIRED / BLOCKED
+  goose_skills_pr_25:
+    status: OPEN / security-review-required
+    submission_thread: block/Agent-Skills#25
+  agent_skill_index_pr_181:
+    status: OPEN / preview-authorization-blocked
+    submission_thread: heilcheng/awesome-agent-skills#181
   official_mcp_registry:
     status: not_submitted
+  awesome_opencode:
+    status: not_submitted
+    blocker: OpenCode remains a compatibility surface in this repo rather than a dedicated Opencode-native project/resource shelf
   ghcr:
     status: not_published
   public_package_and_container_lanes:
@@ -45,6 +54,9 @@ claims_not_made:
   - no live codex directory listing is claimed
   - no live claude marketplace listing is claimed
   - no trust-cleared or vendor-approved clawhub result is claimed
+  - no accepted Goose marketplace listing is claimed beyond PR #25
+  - no accepted agent-skill index directory entry is claimed beyond PR #181
+  - no awesome-opencode project/resource listing is claimed while OpenCode still stays a compatibility surface
   - no official MCP registry submission or publication is claimed
   - no published public docker image or GHCR receipt is claimed
   - no managed hosted runtime is claimed

--- a/plugins/openui-workspace-delivery/README.md
+++ b/plugins/openui-workspace-delivery/README.md
@@ -33,6 +33,11 @@ repo-root docs first:
   `Detected: suspicious.llm_suspicious`
 - the OpenHands lane is real through `OpenHands/extensions#161`, and the
   current GitHub state is `OPEN / REVIEW_REQUIRED / BLOCKED`
+- the Goose lane is real through `block/Agent-Skills#25`, and the current
+  visible blocker is upstream security review after validation passed
+- the agent-skill index lane is real through
+  `heilcheng/awesome-agent-skills#181`, and the current visible blocker is
+  upstream preview authorization rather than a missing repo packet
 - it is still not a live vendor marketplace listing
 - it does not claim a hosted runtime
 - it does not claim vendor approval, a trust-cleared ClawHub result, or an

--- a/plugins/openui-workspace-delivery/manifest.yaml
+++ b/plugins/openui-workspace-delivery/manifest.yaml
@@ -22,15 +22,29 @@ registry_targets:
     channel_role: host-native extensions registry
     submission_thread: OpenHands/extensions#161
     read_back: current GitHub thread is OPEN / REVIEW_REQUIRED / BLOCKED
+  goose-skills-marketplace:
+    status: review_pending
+    package_shape: skill-folder
+    channel_role: host-native skill marketplace
+    submission_thread: block/Agent-Skills#25
+    read_back: validator passed; current visible blocker is upstream security review / CODEOWNERS handling
+  agent-skill-index:
+    status: submission_done
+    package_shape: skill-folder
+    channel_role: public skill index
+    submission_thread: heilcheng/awesome-agent-skills#181
+    read_back: current visible blocker is upstream preview authorization rather than a missing repo packet
 
 boundaries:
   product_identity: Local MCP-first UI generation and review workspace for OpenUI MCP Studio.
   canonical_packet_role: Canonical pure-skills packet for the repo; repo root remains the canonical public root.
   canonical_repo_version: 0.1.0
-  official_listing_state: ClawHub is listed live with a suspicious moderation warning; OpenHands/extensions#161 remains review pending; no official registry listing is claimed
+  official_listing_state: ClawHub is listed live with a suspicious moderation warning; OpenHands/extensions#161 remains review pending; Goose PR #25 and agent-skill index PR #181 are submitted but not yet accepted; no official registry listing is claimed
   not_claimed:
     - No accepted OpenHands/extensions listing exists yet
     - No trust-cleared ClawHub result exists yet
+    - No accepted Goose marketplace listing exists yet beyond PR #25
+    - No accepted agent-skill directory entry exists yet beyond PR #181
     - No live official marketplace listing exists yet
     - No hosted runtime or managed API publication is claimed
 


### PR DESCRIPTION
## Summary
- sync Goose and agent-skill receipt truth across the root public surfaces
- mirror the same receipt state into the canonical pure-skills packet
- keep awesome-opencode explicitly paused as not submitted

## Verification
- python3 YAML parse for root and packet manifests
- git diff --check
- npm run docs:check:strict