### PR TITLE
chore: rename top-level manifest to openuistudio

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 	],
 	"license": "MIT",
 	"main": ".runtime-cache/build/mcp-server/services/mcp-server/src/main.js",
-	"name": "openui-mcp-studio",
+	"name": "openuistudio",
 	"packageManager": "npm@11.6.0",
 	"workspaces": [
 		"apps/*",


### PR DESCRIPTION
Sync top-level package/cargo/pyproject `name` field to match the new GitHub repo name **openuistudio**.

Part of the 17-repo brand-rename plan (-yard / Open- / *Me families).